### PR TITLE
Add ARM64 support to sofa-rpc and add ARM64 job to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,21 @@ dist: trusty
 jdk:
   - oraclejdk8
 
+arch:
+  - amd64
+  - arm64
+
 cache:
   directories:
     - $HOME/.m2
 
 install:
+  - if [ "${TRAVIS_CPU_ARCH}" == "arm64" ]; then
+     sudo apt-get update;
+     sudo apt-get install -y maven openjdk-8-jdk;
+     export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-arm64;
+     export PATH=$JAVA_HOME/bin:$PATH;
+    fi
   - ./mvnw clean install -Pci-install -B -U -e
   - sh ./tools/check_format.sh
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -371,8 +371,14 @@
             <dependency>
                 <groupId>com.pszymczyk.consul</groupId>
                 <artifactId>embedded-consul</artifactId>
-                <version>2.1.4</version>
+                <version>2.2.0</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>3.0.6</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>com.alibaba.nacos</groupId>
@@ -500,8 +506,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>2.0.25.Final</version>
-                <classifier>${os.detected.classifier}</classifier>
+                <version>2.0.34.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.mortbay.jetty.alpn</groupId>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <classifier>${os.detected.classifier}</classifier>
+            <version>2.0.34.Final</version>
         </dependency>
     </dependencies>
 

--- a/registry/registry-consul/pom.xml
+++ b/registry/registry-consul/pom.xml
@@ -56,7 +56,14 @@
         <dependency>
             <groupId>com.pszymczyk.consul</groupId>
             <artifactId>embedded-consul</artifactId>
+            <version>2.2.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>3.0.6</version>
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/registry/registry-sofa/pom.xml
+++ b/registry/registry-sofa/pom.xml
@@ -17,6 +17,11 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>org.rocksdb</groupId>
+            <artifactId>rocksdbjni</artifactId>
+            <version>6.11.4</version>
+        </dependency>
+        <dependency>
             <groupId>com.alipay.sofa</groupId>
             <artifactId>sofa-rpc-log</artifactId>
         </dependency>

--- a/registry/registry-sofa/pom.xml
+++ b/registry/registry-sofa/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.rocksdb</groupId>
             <artifactId>rocksdbjni</artifactId>
-            <version>6.11.4</version>
+            <version>6.4.6</version>
         </dependency>
         <dependency>
             <groupId>com.alipay.sofa</groupId>

--- a/remoting/remoting-http/pom.xml
+++ b/remoting/remoting-http/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-tcnative-boringssl-static</artifactId>
-          <classifier>${os.detected.classifier}</classifier>
+          <version>2.0.34.Final</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
**Hi**

**Package Owner:** Rahul Aggarwal

**PR change Details:**

**1. Patch Details:** Following 6 files have been modified :

1. _.travis.yml:_ 'arm64' architecture has been added, and PATH/JAVA_HOME is set to OpenJDK-8-JDK.
2. _/bom/pom.xml:_ Updated 'netty-tcnative-boringssl-static' dependency's version to 2.0.34.Final, updated 'embedded-consul' version to 2.2.0 and added 'groovy-all' dependency for ARM64 support.
3. _example/pom.xml:_ Updated 'netty-tcnative-boringssl-static' dependency's version to 2.0.34.Final.
4. _registry/registry-consul/pom.xml:_ Updated 'embedded-consul' version to 2.2.0 and added 'groovy-all' dependency for ARM64 support.
5. _registry/registry-sofa/pom.xml:_ Added 'rocksDB' dependency for AArch64 support.
6. _remoting/remoting-http/pom.xml:_ Updated 'netty-tcnative-boringssl-static' dependency's version to 2.0.34.Final for AArch64 support.

**2. Testing Detail:**
Please find my Travis-ci testing jobs here: <https://travis-ci.com/github/ra9501576600git/sofa-rpc/builds/188168172>

**3. PR Description:** Here is my commit message :

_1. Added ARM64 architecture to .travis.yml with openjdk-8-jdk._
_2. Updated 'netty-tcnative-boringssl-static' dependency's version to 2.0.34.Final for AArch64 support._
_3. Updated 'embedded-consul' version to 2.2.0 and added 'groovy-all' dependency for ARM64 support._
_4. Added 'rocksDB' dependency to registry-sofa's pom.xml for AArch64 support._

_Signed-off-by: odidev <odidev@puresoftware.com>_

**4. Peer Reviewer:** Pruthvi Teja
**5. Reviewer:** Rajeev Nayan

**Thanks
Rahul Aggarwal**

